### PR TITLE
Remove the hardset region from the install instructions

### DIFF
--- a/vpc-lattice-config/files/clusterconfig.yaml
+++ b/vpc-lattice-config/files/clusterconfig.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 
 metadata:
   name: ${CLUSTER_NAME}
-  region: us-west-2
+  region: ${AWS_REGION}
 
 fargateProfiles:
   - name: fargate-productcatalog


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `us-west-2` region was hardset in the app mesh controller installer and in the container images. I have removed this and used the $AWS_REGION variable set at the beginning. Additionally my linter has removed a lot of blank space from this file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
