### PR TITLE
Updating ECS instructions to work on both AL2023 and MacOS

### DIFF
--- a/ecs/appmesh-lattice-onboarding-files/appmesh-integration-readme.md
+++ b/ecs/appmesh-lattice-onboarding-files/appmesh-integration-readme.md
@@ -48,7 +48,7 @@ echo "export CLOUDMAP_NAMESPACE_ID=$CLOUDMAP_NAMESPACE_ID" >> $GIT_BASE_DIR/acco
 2. Create `product-service-discovery.json` file from the template and create a Cloud Map service:
 
 ```bash
-sed 's/CLOUDMAP_NAMESPACE_ID/'$CLOUDMAP_NAMESPACE_ID'/g' product-service-discovery.json.template > product-service-discovery.json
+perl -pe 's/CLOUDMAP_NAMESPACE_ID/'$CLOUDMAP_NAMESPACE_ID'/g' product-service-discovery.json.template > product-service-discovery.json
 export CLOUDMAP_SERVICE_ID=`aws servicediscovery create-service \
   --cli-input-json file://product-service-discovery.json \
   --region us-west-2 --query "Service.Id" --output text`
@@ -67,10 +67,10 @@ chmod +x collect_account_details.sh
 - Run commands to modify placeholders AURORA_PG_PARAMETER, ACCOUNT_ID, ECS_TASK_ROLE and ECS_TASK_EXECUTION_ROLE.
 
 ```bash
-sed 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-taskdef.json.template > product-taskdef.json
-sed -i '' 's/ECS_TASK_ROLE/'$ECS_TASK_ROLE'/g' product-taskdef.json
-sed -i '' 's/ECS_TASK_EXECUTION_ROLE/'$ECS_TASK_EXECUTION_ROLE'/g' product-taskdef.json
-sed -i '' 's/AURORA_PG_PARAMETER/'$AURORA_PG_PARAMETER'/g' product-taskdef.json
+perl -pe 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-taskdef.json.template > product-taskdef.json
+perl -pi -e 's/ECS_TASK_ROLE/'$ECS_TASK_ROLE'/g' product-taskdef.json
+perl -pi -e 's/ECS_TASK_EXECUTION_ROLE/'$ECS_TASK_EXECUTION_ROLE'/g' product-taskdef.json
+perl -pi -e 's/AURORA_PG_PARAMETER/'$AURORA_PG_PARAMETER'/g' product-taskdef.json
 ```
 
 - Execute below command to register the task definition
@@ -143,14 +143,14 @@ aws iam put-role-policy \
 - Run commands to modify placeholders CLUSTER_NAME, SUBNET1/2/3, task SECURITY_GROUP_ID, etc.
 
 ```bash
-sed 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-service.json.template > product-service.json
-sed -i '' 's/CLUSTER_NAME/'$CLUSTER_NAME'/g' product-service.json
-sed -i '' 's/PRODUCT_TASKDEF_REVISION/'$PRODUCT_TASKDEF_REVISION'/g' product-service.json
-sed -i '' 's/CLOUDMAP_SERVICE_ID/'$CLOUDMAP_SERVICE_ID'/g' product-service.json
-sed -i '' 's/SECURITY_GROUP_ID/'$SECURITY_GROUP_ID'/g' product-service.json
-sed -i '' 's/SUBNET1/'$SUBNET1'/g' product-service.json
-sed -i '' 's/SUBNET2/'$SUBNET2'/g' product-service.json
-sed -i '' 's/SUBNET3/'$SUBNET3'/g' product-service.json
+perl -pe 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-service.json.template > product-service.json
+perl -pi -e 's/CLUSTER_NAME/'$CLUSTER_NAME'/g' product-service.json
+perl -pi -e 's/PRODUCT_TASKDEF_REVISION/'$PRODUCT_TASKDEF_REVISION'/g' product-service.json
+perl -pi -e 's/CLOUDMAP_SERVICE_ID/'$CLOUDMAP_SERVICE_ID'/g' product-service.json
+perl -pi -e 's/SECURITY_GROUP_ID/'$SECURITY_GROUP_ID'/g' product-service.json
+perl -pi -e 's/SUBNET1/'$SUBNET1'/g' product-service.json
+perl -pi -e 's/SUBNET2/'$SUBNET2'/g' product-service.json
+perl -pi -e 's/SUBNET3/'$SUBNET3'/g' product-service.json
 ```
 
 - Create the ECS service

--- a/ecs/appmesh-lattice-onboarding-files/vpc-lattice-migration-readme.md
+++ b/ecs/appmesh-lattice-onboarding-files/vpc-lattice-migration-readme.md
@@ -20,10 +20,10 @@ cd ../appmesh-lattice-onboarding-files/
 - Run commands to modify placeholders AURORA_PG_PARAMETER, ACCOUNT_ID, ECS_TASK_ROLE and ECS_TASK_EXECUTION_ROLE.
 
 ```bash
-sed 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-taskdef-lattice.json.template > product-taskdef-lattice.json
-sed -i '' 's/ECS_TASK_ROLE/'$ECS_TASK_ROLE'/g' product-taskdef-lattice.json
-sed -i '' 's/ECS_TASK_EXECUTION_ROLE/'$ECS_TASK_EXECUTION_ROLE'/g' product-taskdef-lattice.json
-sed -i '' 's/AURORA_PG_PARAMETER/'$AURORA_PG_PARAMETER'/g' product-taskdef-lattice.json
+perl -pe 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-taskdef-lattice.json.template > product-taskdef-lattice.json
+perl -pi -e 's/ECS_TASK_ROLE/'$ECS_TASK_ROLE'/g' product-taskdef-lattice.json
+perl -pi -e 's/ECS_TASK_EXECUTION_ROLE/'$ECS_TASK_EXECUTION_ROLE'/g' product-taskdef-lattice.json
+perl -pi -e 's/AURORA_PG_PARAMETER/'$AURORA_PG_PARAMETER'/g' product-taskdef-lattice.json
 ```
 
 - Execute below command to register the task definition
@@ -173,14 +173,14 @@ aws iam attach-role-policy --role-name ecsLatticeRole --policy-arn arn:aws:iam::
 - Replace placeholders CLUSTER_NAME, SUBNET1/2/3, SECURITY_GROUP_ID, LATTICE_ROLE, and LATTICE_TARGET_GROUP, etc.
 
 ```bash
-sed 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-service-lattice.json.template > product-service-lattice.json
-sed -i '' 's/CLUSTER_NAME/'$CLUSTER_NAME'/g' product-service-lattice.json
-sed -i '' 's/PRODUCT_TASKDEF_LATTICE_REVISION/'$PRODUCT_TASKDEF_LATTICE_REVISION'/g' product-service-lattice.json
-sed -i '' 's/SECURITY_GROUP_ID/'$SECURITY_GROUP_ID'/g' product-service-lattice.json
-sed -i '' 's/SUBNET1/'$SUBNET1'/g' product-service-lattice.json
-sed -i '' 's/SUBNET2/'$SUBNET2'/g' product-service-lattice.json
-sed -i '' 's/SUBNET3/'$SUBNET3'/g' product-service-lattice.json
-sed -i '' 's/LATTICE_PRODUCT_TG_ID/'$LATTICE_PRODUCT_TG_ID'/g' product-service-lattice.json
+perl -pe 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' product-service-lattice.json.template > product-service-lattice.json
+perl -pi -e 's/CLUSTER_NAME/'$CLUSTER_NAME'/g' product-service-lattice.json
+perl -pi -e 's/PRODUCT_TASKDEF_LATTICE_REVISION/'$PRODUCT_TASKDEF_LATTICE_REVISION'/g' product-service-lattice.json
+perl -pi -e 's/SECURITY_GROUP_ID/'$SECURITY_GROUP_ID'/g' product-service-lattice.json
+perl -pi -e 's/SUBNET1/'$SUBNET1'/g' product-service-lattice.json
+perl -pi -e 's/SUBNET2/'$SUBNET2'/g' product-service-lattice.json
+perl -pi -e 's/SUBNET3/'$SUBNET3'/g' product-service-lattice.json
+perl -pi -e 's/LATTICE_PRODUCT_TG_ID/'$LATTICE_PRODUCT_TG_ID'/g' product-service-lattice.json
 ```
 
 - Create the ECS service:

--- a/ecs/collect_account_details.sh
+++ b/ecs/collect_account_details.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 export ACCOUNT_ID=`aws sts get-caller-identity --query "Account" --output text`
+
+#Disable AWS CLI command response pagination
+export AWS_PAGER=''
+
 chmod a+x $GIT_BASE_DIR/account_details.sh
 echo "export ACCOUNT_ID=$ACCOUNT_ID" >> $GIT_BASE_DIR/account_details.sh
+echo "export AWS_PAGER=''" >> $GIT_BASE_DIR/account_details.sh
 
 read -p "Enter the VPC ID to deploy AppMesh, VPC Lattice and ALB resources: " VPC_ID
 echo "export VPC_ID=$VPC_ID" >> $GIT_BASE_DIR/account_details.sh

--- a/ecs/frontend-ms/frontend-readme.md
+++ b/ecs/frontend-ms/frontend-readme.md
@@ -26,9 +26,9 @@ chmod +x collect_account_details.sh
 - Run commands to modify placeholders for ACCOUNT_ID, ECS_TASK_ROLE, ECS_TASK_EXECUTION_ROLE.
 
 ```bash
-sed 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' frontend-taskdef.json.template > frontend-taskdef.json
-sed -i '' 's/ECS_TASK_ROLE/'$ECS_TASK_ROLE'/g' frontend-taskdef.json
-sed -i '' 's/ECS_TASK_EXECUTION_ROLE/'$ECS_TASK_EXECUTION_ROLE'/g' frontend-taskdef.json
+perl -pe 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' frontend-taskdef.json.template > frontend-taskdef.json
+perl -pi -e 's/ECS_TASK_ROLE/'$ECS_TASK_ROLE'/g' frontend-taskdef.json
+perl -pi -e 's/ECS_TASK_EXECUTION_ROLE/'$ECS_TASK_EXECUTION_ROLE'/g' frontend-taskdef.json
 ```
 
 **Note:** Nginx server in Frontend UI application expects valid DNS values for order-ms, user-ms and product-ms services. For the purposes of this workshop, we only deployed product-ms service, so we will use product-ms App Mesh URL for 3 environment variables in the task definition. If you choose to fully deploy order-ms and user-ms, update USERS_DOMAIN environment variable value in `frontend-taskdef.json` with user-ms.inventory-mesh.local:4000 and ORDERS_DOMAIN environment variable value with order-ms.inventory-mesh.local:7000.
@@ -94,16 +94,16 @@ aws iam attach-role-policy \
 - Run commands to modify placeholders CLUSTER_NAME, SUBNET1/2/3, task SECURITY_GROUP_ID, etc.
 
 ```bash
-sed 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' frontend-service.json.template > frontend-service.json
-sed -i '' 's/CLUSTER_NAME/'$CLUSTER_NAME'/g' frontend-service.json
-sed -i '' 's/FRONTEND_TASKDEF_REVISION/'$FRONTEND_TASKDEF_REVISION'/g' frontend-service.json
-sed -i '' 's/SECURITY_GROUP_ID/'$SECURITY_GROUP_ID'/g' frontend-service.json
-sed -i '' 's/SUBNET1/'$SUBNET1'/g' frontend-service.json
-sed -i '' 's/SUBNET2/'$SUBNET2'/g' frontend-service.json
-sed -i '' 's/SUBNET3/'$SUBNET3'/g' frontend-service.json
-sed -i '' 's#BLUE_TARGET_GROUP_ARN#'$BLUE_TARGET_GROUP_ARN'#g' frontend-service.json
-sed -i '' 's#GREEN_TARGET_GROUP_ARN#'$GREEN_TARGET_GROUP_ARN'#g' frontend-service.json
-sed -i '' 's#LISTENER_RULE_ARN#'$LISTENER_RULE_ARN'#g' frontend-service.json
+perl -pe 's/ACCOUNT_ID/'$ACCOUNT_ID'/g' frontend-service.json.template > frontend-service.json
+perl -pi -e 's/CLUSTER_NAME/'$CLUSTER_NAME'/g' frontend-service.json
+perl -pi -e 's/FRONTEND_TASKDEF_REVISION/'$FRONTEND_TASKDEF_REVISION'/g' frontend-service.json
+perl -pi -e 's/SECURITY_GROUP_ID/'$SECURITY_GROUP_ID'/g' frontend-service.json
+perl -pi -e 's/SUBNET1/'$SUBNET1'/g' frontend-service.json
+perl -pi -e 's/SUBNET2/'$SUBNET2'/g' frontend-service.json
+perl -pi -e 's/SUBNET3/'$SUBNET3'/g' frontend-service.json
+perl -pi -e 's#BLUE_TARGET_GROUP_ARN#'$BLUE_TARGET_GROUP_ARN'#g' frontend-service.json
+perl -pi -e 's#GREEN_TARGET_GROUP_ARN#'$GREEN_TARGET_GROUP_ARN'#g' frontend-service.json
+perl -pi -e 's#LISTENER_RULE_ARN#'$LISTENER_RULE_ARN'#g' frontend-service.json
 ```
 
 - Ensure the ECS Task Security Group can receive traffic at least from ALB security group on port 3000

--- a/ecs/frontend-ms/frontend-taskdef.json.template
+++ b/ecs/frontend-ms/frontend-taskdef.json.template
@@ -66,8 +66,8 @@
         }
     ],
     "family": "frontend-ui",
-    "taskRoleArn": "ECS_TASK_ROLE",
-    "executionRoleArn": "ECS_TASK_EXECUTION_ROLE",
+    "executionRoleArn": "arn:aws:iam::ACCOUNT_ID:role/ECS_TASK_EXECUTION_ROLE",
+    "taskRoleArn": "arn:aws:iam::ACCOUNT_ID:role/ECS_TASK_ROLE",
     "networkMode": "awsvpc",
     "volumes": [],
     "placementConstraints": [],


### PR DESCRIPTION
*Description of changes:*

- Switched from sed to perl for substitution
- Disabled pagination in AWS CLI output
- Updated frontend task definition templates to use role ARNs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
